### PR TITLE
Create monitoring namespace

### DIFF
--- a/clusters/base/kube-prometheus-stack.yaml
+++ b/clusters/base/kube-prometheus-stack.yaml
@@ -15,8 +15,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 24h
-  install:
-    createNamespace: true
   chart:
     spec:
       chart: kube-prometheus-stack

--- a/clusters/base/monitoring-namespace.yaml
+++ b/clusters/base/monitoring-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring


### PR DESCRIPTION
Fix for error we hit in https://github.com/cncf-tags/green-reviews-tooling/actions/runs/7628160767

The kepler dashboard configmap is created by Flux so we need to create the namespace.
