### PR TITLE
Move falco gitrepo CR to falco namespace

### DIFF
--- a/clusters/projects/falco/falco.yaml
+++ b/clusters/projects/falco/falco.yaml
@@ -6,7 +6,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: falco-cncf-green-review-testing
-  namespace: flux-system
+  namespace: falco
 spec:
   interval: 6h
   ref:


### PR DESCRIPTION
Follow up to #21 

Reconciling the kustomization failed because the gitrepo was in the flux-system namespace.

@nikimanoledaki Should we keep both resources in the falco ns? I'm not sure what the best practice is here.
