### PR TITLE
Exposing Grafana dashboards publicly accessible from cluster using ingress

### DIFF
--- a/clusters/base/kube-prometheus-stack.yaml
+++ b/clusters/base/kube-prometheus-stack.yaml
@@ -23,6 +23,9 @@ spec:
         kind: HelmRepository
         name: prometheus
   values:
+    grafana:
+      ingress:
+        enabled: true
     prometheus:
       prometheusSpec:
         serviceMonitorSelectorNilUsesHelmValues: false

--- a/clusters/projects/falco/falco.yaml
+++ b/clusters/projects/falco/falco.yaml
@@ -6,7 +6,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: falco-cncf-green-review-testing
-  namespace: flux-system
+  namespace: falco
 spec:
   interval: 6h
   ref:


### PR DESCRIPTION
Adding ingress to Grafana in kube-prometheus-stack.yaml

@rossf7, Thank you validating this change. 