### PR TITLE
Use updated S3 bucket name

### DIFF
--- a/infrastructure/equinix-metal/main.tf
+++ b/infrastructure/equinix-metal/main.tf
@@ -11,7 +11,7 @@ terraform {
   }
 
   backend "s3" {
-    bucket  = "green-reviews-state-bucket"
+    bucket  = "tag-env-green-reviews-open-tofu"
     key     = "opentofu/terraform.tfstate"
     region  = "eu-central-1"
     encrypt = true


### PR DESCRIPTION
See https://github.com/cncf-tags/green-reviews-tooling/issues/8

Uses new S3 bucket created in CNCF's AWS account.

@leonardpahlke Can you update the GH secrets? This can then be merged.