### PR TITLE
feat: Exposing Grafana dashboards publicly accessible from cluster

### DIFF
--- a/clusters/base/kube-prometheus-stack.yaml
+++ b/clusters/base/kube-prometheus-stack.yaml
@@ -23,6 +23,9 @@ spec:
         kind: HelmRepository
         name: prometheus
   values:
+    grafana:
+      ingress:
+        enabled: true
     prometheus:
       prometheusSpec:
         serviceMonitorSelectorNilUsesHelmValues: false


### PR DESCRIPTION
Towards https://github.com/cncf-tags/green-reviews-tooling/issues/31

Add ingress to Grafana in kube-prometheus-stack.yaml

Replaces https://github.com/cncf-tags/green-reviews-tooling/pull/42 from @greenscale-nandesh as a workaround to  problem with signed commits