### PR TITLE
feat: Make node labels and plan configurable

### DIFF
--- a/infrastructure/equinix-metal/main.tf
+++ b/infrastructure/equinix-metal/main.tf
@@ -60,9 +60,9 @@ resource "equinix_metal_device" "control_plane" {
 }
 
 resource "equinix_metal_device" "worker" {
-  for_each            = toset(var.worker_nodes)
-  hostname            = "${var.cluster_name}-${each.value}"
   plan                = var.device_plan
+  for_each            = var.worker_nodes
+  hostname            = "${var.cluster_name}-worker-${each.key}"
   metro               = var.device_metro
   operating_system    = var.device_os
   billing_cycle       = var.billing_cycle
@@ -71,7 +71,10 @@ resource "equinix_metal_device" "worker" {
   depends_on          = [equinix_metal_device.control_plane]
   user_data           = <<EOF
 #!/bin/bash
-curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="${var.k3s_version}" sh -s - agent --token "${var.k3s_token}" --server "https://${equinix_metal_device.control_plane.access_private_ipv4}:6443"
+curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="${var.k3s_version}" sh -s - agent \
+--token "${var.k3s_token}" \
+--server "https://${equinix_metal_device.control_plane.access_private_ipv4}:6443" \
+${join(" \\\n", [for k, v in each.value.labels : "--node-label ${k}=${v}"])}
 EOF
 
   behavior {

--- a/infrastructure/equinix-metal/main.tf
+++ b/infrastructure/equinix-metal/main.tf
@@ -60,9 +60,9 @@ resource "equinix_metal_device" "control_plane" {
 }
 
 resource "equinix_metal_device" "worker" {
-  plan                = var.device_plan
   for_each            = var.worker_nodes
   hostname            = "${var.cluster_name}-worker-${each.key}"
+  plan                = each.plan
   metro               = var.device_metro
   operating_system    = var.device_os
   billing_cycle       = var.billing_cycle

--- a/infrastructure/equinix-metal/variables.tf
+++ b/infrastructure/equinix-metal/variables.tf
@@ -102,6 +102,24 @@ variable "ssh_private_key_path" {
 
 variable "worker_nodes" {
   description = "List of worker node names"
-  type        = list(string)
-  default     = ["worker1"]
+  type = map(object({
+    labels = map(string)
+    plan   = string
+  }))
+  default = {
+    internal-1 = {
+      labels = {
+        cncf-project     = "wg-green-reviews"
+        cncf-project-sub = "internal"
+      },
+      plan = "m3.small.x86"
+    },
+    falco-a = {
+      labels = {
+        cncf-project     = "falco"
+        cncf-project-sub = "falco-driver-modern-ebpf"
+      },
+      plan = "m3.small.x86"
+    }
+  }
 }


### PR DESCRIPTION
#### What type of PR is this?

kind/feature

#### What this PR does / why we need it:

- Makes node labels configurable so we can run Falco and monitoring stack on different nodes.
- Makes Equinix metal plan (their name for instance type) configurable so we can run larger nodes when needed

https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/

#### Which issue(s) this PR fixes:

Towards https://github.com/cncf-tags/green-reviews-tooling/issues/30 and unblocks https://github.com/cncf-tags/green-reviews-tooling/pull/44