### PR TITLE
Add idle-benchmark cron job definition

### DIFF
--- a/clusters/base/idle-benchmark.yaml
+++ b/clusters/base/idle-benchmark.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: idle-benchmark-job
+  namespace: monitoring
+spec:
+  schedule: '* */1 * * *'
+  jobTemplate:
+    metadata:
+      name: idle-benchmark-job
+    spec:
+      template:
+        spec:
+          containers:
+          - name: idle-benchmark-job
+            image: busybox
+            imagePullPolicy: IfNotPresent
+            command:
+            - echo
+            - "idle benchmark"            
+          restartPolicy: OnFailure


### PR DESCRIPTION

#### What type of PR is this?
Feature

#### What this PR does / why we need it:
It creates a CronJob definition that publishes metrics in order to establish a baseline for measurements.

#### Which issue(s) this PR fixes:
Fixes #50

