### PR TITLE
feat: Add node-selector to flux deployments

### DIFF
--- a/clusters/flux-system/kustomization.yaml
+++ b/clusters/flux-system/kustomization.yaml
@@ -3,3 +3,7 @@ kind: Kustomization
 resources:
 - gotk-components.yaml
 - gotk-sync.yaml
+patches:
+- path: node-selector-patch.yaml
+  target:
+    kind: Deployment

--- a/clusters/flux-system/node-selector-patch.yaml
+++ b/clusters/flux-system/node-selector-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cncf-project: wg-green-reviews
+        cncf-project-sub: internal


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://github.com/cncf-tags/green-reviews-tooling/blob/main/CONTRIBUTING.md
- If you want *faster* PR reviews, read the Kubernetes Best Practices: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
kind/bug
kind/documentation
kind/feature
kind/enhancement
-->

kind/enhancement

#### What this PR does / why we need it:

Adds node selectors to the Flux deployments so they run on our internal node and not the Falco node that we are measuring energy consumption.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Fixes https://github.com/cncf-tags/green-reviews-tooling/issues/30

