### PR TITLE
fix: Helm chart name in microservices demo helmrelease

### DIFF
--- a/clusters/projects/falco/microservices-demo.yaml
+++ b/clusters/projects/falco/microservices-demo.yaml
@@ -18,7 +18,7 @@ spec:
   interval: 24h
   chart:
     spec:
-      chart: online-boutique
+      chart: onlineboutique
       sourceRef:
         kind: HelmRepository
         name: online-boutique


### PR DESCRIPTION
#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:

The microservices demo wasn't deployed because of a typo in the chart name.

```
k get helmcharts.source.toolkit.fluxcd.io -n falco falco-online-boutique
NAME                    CHART             VERSION   SOURCE KIND      SOURCE NAME       AGE   READY   STATUS
falco-online-boutique   online-boutique   *         HelmRepository   online-boutique   20d   False   chart pull error: failed to get chart version for remote reference: could not get tags for "online-boutique": unable to locate any tags in provided repository: oci://us-docker.pkg.dev/online-boutique-ci/charts/online-boutique
```

See https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/helm-chart