### PR TITLE
feat: Add elastic ip for Grafana

### DIFF
--- a/infrastructure/equinix-metal/main.tf
+++ b/infrastructure/equinix-metal/main.tf
@@ -31,8 +31,7 @@ resource "equinix_metal_project_ssh_key" "ssh_key" {
 resource "equinix_metal_reserved_ip_block" "elastic_ip" {
   for_each   = toset(var.elastic_ips)
   project_id = var.equinix_project_id
-  type       = "public_ipv4"
-  metro      = var.device_metro
+  type       = "global_ipv4"
   quantity   = 1
   description = each.value
 }

--- a/infrastructure/equinix-metal/variables.tf
+++ b/infrastructure/equinix-metal/variables.tf
@@ -34,6 +34,12 @@ variable "device_plan" {
   default     = "m3.small.x86"
 }
 
+variable "elastic_ips" {
+  description = "List of Equinix Metal elastic ip names"
+  type        = list(string)
+  default     = ["monitoring"]
+}
+
 variable "equinix_auth_token" {
   description = "Authentication token for Equinix Metal"
   type        = string
@@ -103,11 +109,13 @@ variable "ssh_private_key_path" {
 variable "worker_nodes" {
   description = "Map of worker nodes and config"
   type = map(object({
+    elastic_ip = string
     labels = map(string)
     plan   = string
   }))
   default = {
     internal-1 = {
+      elastic_ip = "monitoring"
       labels = {
         cncf-project     = "wg-green-reviews"
         cncf-project-sub = "internal"
@@ -115,6 +123,7 @@ variable "worker_nodes" {
       plan = "m3.small.x86"
     },
     falco-a = {
+      elastic_ip = ""
       labels = {
         cncf-project     = "falco"
         cncf-project-sub = "falco-driver-modern-ebpf"


### PR DESCRIPTION
#### What type of PR is this?

kind/feature

#### What this PR does / why we need it:

This creates an Equinix elastic IP named `monitoring` and assigns it to the node where Grafana is deployed.

This will allow us to request a DNS record for `green-reviews.tag-env-sustainability.cncf.io`

#### Which issue(s) this PR fixes:

Towards https://github.com/cncf-tags/green-reviews-tooling/issues/31

#### Special notes for your reviewer (optional):

- Elastic IPs are not automatically added so this is done using `netplan` since the machines run Ubuntu
https://deploy.equinix.com/developers/docs/metal/networking/elastic-ips/#host-ip-configuration
- The elastic IP is also configured with K3s by setting the `--node-external-ip` flag
https://docs.k3s.io/cli/agent#networking
- With this Grafana is accessible in my test cluster at the external IP
```
k get no -o wide
NAME                              STATUS   ROLES                  AGE   VERSION        INTERNAL-IP     EXTERNAL-IP     OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
green-reviews-worker-falco-a      Ready    <none>                 26m   v1.29.0+k3s1   147.28.133.63   <none>          Ubuntu 22.04.4 LTS   5.15.0-94-generic   containerd://1.7.11-k3s2
green-reviews-worker-internal-1   Ready    <none>                 25m   v1.29.0+k3s1   147.28.134.59   147.28.133.50   Ubuntu 22.04.4 LTS   5.15.0-94-generic   containerd://1.7.11-k3s2
green-reviews-control-plane       Ready    control-plane,master   28m   v1.29.0+k3s1   147.28.134.47   <none>          Ubuntu 22.04.4 LTS   5.15.0-94-generic   containerd://1.7.11-k3s2
```


