### PR TITLE
fix: Updates to proposal 1

### DIFF
--- a/docs/proposals/proposal-001-trigger-and-deploy.md
+++ b/docs/proposals/proposal-001-trigger-and-deploy.md
@@ -129,8 +129,12 @@ projects:
       - kmod
 ```
 
-A scheduled GitHub Action will run every hour and check the Atom feed of
-each project for new releases. To manage the state a GitHub [repository variable](https://docs.github.com/en/actions/learn-github-actions/variables)
+A scheduled GitHub Action will run weekly and check the Atom feed of
+each project for new releases.
+
+e.g. https://github.com/falcosecurity/falco/releases.atom
+
+To manage the state a GitHub [repository variable](https://docs.github.com/en/actions/learn-github-actions/variables)
 per CNCF project is used to store the latest release version.
 
 If a new release is detected the action will trigger the pipeline for the new

--- a/docs/proposals/proposal-001-trigger-and-deploy.md
+++ b/docs/proposals/proposal-001-trigger-and-deploy.md
@@ -57,7 +57,7 @@ multiple configurations of Falco and more CNCF projects as they are onboarded.
 
 ### Goals
 
-- Trigger the pipeline when a new release of a project happens
+- Trigger the pipeline once a day for the latest version of the project
 - Allow additional runs of the pipeline by calling a GitHub webhook
 - Deploy the new version of the project using flux
 - Delete the resources at the end of the pipeline run
@@ -75,7 +75,7 @@ team
 
 ## Proposal
 
-We will watch for new releases of the project via the GitHub REST API
+Once a day we will get the latest release of the project via the GitHub REST API
 e.g. https://api.github.com/repos/falcosecurity/falco/releases/latest
 
 Our automation will call the GitHub REST API to trigger the pipeline.
@@ -135,24 +135,17 @@ tooling repo e.g.
 }
 ```
 
-A scheduled GitHub Action will run weekly and check the GitHub REST API of each
-project for new releases.
+A scheduled GitHub Action will run once a day and check the GitHub REST API of
+each project for its latest release.
 
 e.g. https://api.github.com/repos/falcosecurity/falco/releases/latest
-
-To manage the state a GitHub [repository variable](https://docs.github.com/en/actions/learn-github-actions/variables)
-per CNCF project is used to store the latest release version.
-
-If a new release is detected the action will trigger the pipeline for the new
-release and update the variable with the new version. This is to ensure each
-release is only triggered once.
 
 If sub components are specified then the pipeline will be triggered once per
 sub component.
 
 ### Trigger
 
-The green reviews pipeline will be triggered by sending a [workflow_dispatch](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)
+The benchmark pipeline will be triggered by sending a [workflow_dispatch](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)
 event via the GitHub REST API.
 
 Inputs are
@@ -167,7 +160,7 @@ and `ebpf`
 curl -X POST \
      -H "Accept: application/vnd.github.v3+json" \
      -H "Authorization: token $GITHUB_PAT" \
-     https://api.github.com/repos/cncf-tags/green-reviews-tooling/actions/workflows/pipeline.yaml/dispatches \
+     https://api.github.com/repos/cncf-tags/green-reviews-tooling/actions/workflows/benchmark-pipeline.yaml/dispatches \
      -d '{"ref":"0.2.0", "inputs": {"cncf_project": "falco", "cncf_project_sub": "modern-ebpf","version":"0.37.0"}}'
 ```
 

--- a/docs/proposals/proposal-001-trigger-and-deploy.md
+++ b/docs/proposals/proposal-001-trigger-and-deploy.md
@@ -135,13 +135,15 @@ tooling repo e.g.
 }
 ```
 
-A scheduled GitHub Action will run once a day and check the GitHub REST API of
-each project for its latest release.
+A scheduled GitHub Action will run once a day at 08:00 UTC and check the GitHub
+REST API of each project for its latest release.
 
 e.g. https://api.github.com/repos/falcosecurity/falco/releases/latest
 
 If sub components are specified then the pipeline will be triggered once per
 sub component.
+
+Note: 08:00 UTC is chosen to be during daylight when solar energy should be available.
 
 ### Trigger
 

--- a/docs/proposals/proposal-001-trigger-and-deploy.md
+++ b/docs/proposals/proposal-001-trigger-and-deploy.md
@@ -125,7 +125,7 @@ Optionally multiple configurations of a CNCF project can be deployed e.g.
         {
             "name": "falco",
             "organization": "falcosecurity",
-            "configurations": [
+            "config": [
                 "ebpf",
                 "modern-ebpf",
                 "kmod"

--- a/docs/proposals/proposal-001-trigger-and-deploy.md
+++ b/docs/proposals/proposal-001-trigger-and-deploy.md
@@ -125,7 +125,7 @@ tooling repo e.g.
         {
             "name": "falco",
             "organization": "falcosecurity",
-            "sub_components": [
+            "configurations": [
                 "ebpf",
                 "modern-ebpf",
                 "kmod"
@@ -140,8 +140,8 @@ REST API of each project for its latest release.
 
 e.g. https://api.github.com/repos/falcosecurity/falco/releases/latest
 
-If sub components are specified then the pipeline will be triggered once per
-sub component.
+If configurations are specified then the pipeline will be triggered once per
+configuration.
 
 Note: 08:00 UTC is chosen to be during daylight when solar energy should be available.
 
@@ -153,7 +153,7 @@ event via the GitHub REST API.
 Inputs are
 
 - `cncf_project`: **required** Project to be deployed e.g. `falco`
-- `cncf_project_sub`: **optional** Subcomponent if project has multiple variants
+- `config`: **optional** Configuration if project has multiple variants
 they wish to test e.g. Falco wish to test 3 falco drivers `modern-ebpf`, `kmod`
 and `ebpf`
 - `version`: **required** Version of project to be tested e.g. `0.37.0`
@@ -163,7 +163,7 @@ curl -X POST \
      -H "Accept: application/vnd.github.v3+json" \
      -H "Authorization: token $GITHUB_PAT" \
      https://api.github.com/repos/cncf-tags/green-reviews-tooling/actions/workflows/benchmark-pipeline.yaml/dispatches \
-     -d '{"ref":"0.2.0", "inputs": {"cncf_project": "falco", "cncf_project_sub": "modern-ebpf","version":"0.37.0"}}'
+     -d '{"ref":"0.2.0", "inputs": {"cncf_project": "falco", "config": "modern-ebpf","version":"0.37.0"}}'
 ```
 
 The pipeline is versioned by creating releases of the `green-reviews-tooling`
@@ -182,7 +182,7 @@ Flux is used to deploy the CNCF project. Projects are able to use either
 
 When the pipeline executes it will look for manifest files in the projects dir.
 If there is a manifest matching the `cncf_project` input its contents will be
-applied using kubectl. The same applies for the `cncf_project_sub` input. 
+applied using kubectl. The same applies for the `config` input.
 
 The `version` param is injected into the files to ensure the correct version of
 the project is deployed. (For these minor changes we can utilize kustomize)
@@ -214,7 +214,7 @@ project resources will be deleted by deleting their flux resources.
 A successful pipeline run is once the necessary metrics have been written to
 long term storage. This will be covered by proposal 3 [Report](https://github.com/cncf-tags/green-reviews-tooling/issues/95).
 
-The same logic using the `cncf_project` and `cncf_project_sub` inputs will be
+The same logic using the `cncf_project` and `cncf_project_config` inputs will be
 used to select which manifests should be deleted. The manifests will be deleted
 using `kubectl delete -f --wait` so we wait for finalizers.
 

--- a/docs/proposals/proposal-001-trigger-and-deploy.md
+++ b/docs/proposals/proposal-001-trigger-and-deploy.md
@@ -116,17 +116,23 @@ removed. In future we could create nodes on demand and delete on completion.
 
 ### Subscribing to Releases
 
-A YAML file of CNCF projects and any sub components will be stored in the
+A JSON file of CNCF projects and any sub components will be stored in the
 tooling repo e.g.
 
-```yaml
-# projects.yaml
-projects:
-  - name: falco
-    sub_components:
-      - ebpf
-      - modern-ebpf
-      - kmod
+```json
+{
+    "projects": [
+        {
+            "name": "falco",
+            "organization": "falcosecurity",
+            "sub_components": [
+                "ebpf",
+                "modern-ebpf",
+                "kmod"
+            ]
+        }
+    ]
+}
 ```
 
 A scheduled GitHub Action will run weekly and check the GitHub REST API of each

--- a/docs/proposals/proposal-001-trigger-and-deploy.md
+++ b/docs/proposals/proposal-001-trigger-and-deploy.md
@@ -75,8 +75,8 @@ team
 
 ## Proposal
 
-We will watch for new releases of the project by subscribing to the Atom feed
-of releases that GitHub publish e.g. https://github.com/falcosecurity/falco/releases.atom
+We will watch for new releases of the project via the GitHub REST API
+e.g. https://api.github.com/repos/falcosecurity/falco/releases/latest
 
 Our automation will call the GitHub REST API to trigger the pipeline.
 
@@ -129,10 +129,10 @@ projects:
       - kmod
 ```
 
-A scheduled GitHub Action will run weekly and check the Atom feed of
-each project for new releases.
+A scheduled GitHub Action will run weekly and check the GitHub REST API of each
+project for new releases.
 
-e.g. https://github.com/falcosecurity/falco/releases.atom
+e.g. https://api.github.com/repos/falcosecurity/falco/releases/latest
 
 To manage the state a GitHub [repository variable](https://docs.github.com/en/actions/learn-github-actions/variables)
 per CNCF project is used to store the latest release version.

--- a/docs/proposals/proposal-001-trigger-and-deploy.md
+++ b/docs/proposals/proposal-001-trigger-and-deploy.md
@@ -116,8 +116,8 @@ removed. In future we could create nodes on demand and delete on completion.
 
 ### Subscribing to Releases
 
-A JSON file of CNCF projects and any sub components will be stored in the
-tooling repo e.g.
+A JSON file of CNCF projects will be stored in the green-reviews-tooling repo.
+Optionally multiple configurations of a CNCF project can be deployed e.g.
 
 ```json
 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://github.com/cncf-tags/green-reviews-tooling/blob/main/CONTRIBUTING.md
- If you want *faster* PR reviews, read the Kubernetes Best Practices: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
kind/bug
kind/documentation
kind/feature
kind/enhancement
-->

kind/documentation

#### What this PR does / why we need it:

Update proposal 1 to 

- Make releases check weekly instead of hourly. As we feel hourly is too often.
- Use releases endpoint instead of Atom feed
- Use JSON not YAML for projects metadata to avoid need for Go YAML library

Also adds missing link to atom feed.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

None

#### Special notes for your reviewer (optional):

cc @dipankardas011 