### PR TITLE
fix: Quote kubeconfig and add sleep to deploy step

### DIFF
--- a/.github/workflows/benchmark-pipeline.yaml
+++ b/.github/workflows/benchmark-pipeline.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           version: v1.30.2
         id: install
-      - run: mkdir ~/.kube && echo ${{ secrets.KUBECONFIG }} > ~/.kube/config
+      - run: mkdir ~/.kube && echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
       - name: Select the manifest
         run: |
           MANIFEST=projects/${{ inputs.cncf_project }}
@@ -51,6 +51,8 @@ jobs:
         run: |
           kubectl apply -f manifest.yaml
 
+          sleep 10
+
           kubectl wait pod \
           --all \
           --for=condition=Ready \
@@ -66,7 +68,7 @@ jobs:
         with:
           version: v1.30.2
         id: install
-      - run: mkdir ~/.kube && echo ${{ secrets.KUBECONFIG }} > ~/.kube/config
+      - run: mkdir ~/.kube && echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://github.com/cncf-tags/green-reviews-tooling/blob/main/CONTRIBUTING.md
- If you want *faster* PR reviews, read the Kubernetes Best Practices: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
kind/bug
kind/documentation
kind/feature
kind/enhancement
-->

kind/bug

#### What this PR does / why we need it:

- Adds quoting to echo statement when creating kubeconfig from secret
- Adds a sleep for 10 seconds before kubectl wait command to allow flux resources to be created.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Follow up to #99 

#### Special notes for your reviewer (optional):

cc @dipankardas011

