### PR TITLE
fix: Only trigger on script changes and align naming

### DIFF
--- a/.github/workflows/benchmark-pipeline.yaml
+++ b/.github/workflows/benchmark-pipeline.yaml
@@ -1,4 +1,5 @@
-name: benchmark-pipeline
+name: Benchmark Pipeline
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/project-trigger.yml
+++ b/.github/workflows/project-trigger.yml
@@ -1,12 +1,13 @@
-name: Reconciles Project Versions and triggers them
+name: Project Trigger
 
 on:
   schedule:
     - cron: '0 8 * * *'
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
+    branches:
+    - main
+    paths:
+    - 'scripts/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/tofu.yaml
+++ b/.github/workflows/tofu.yaml
@@ -1,4 +1,4 @@
-name: OpenTofu
+name: Tofu Apply
 
 on:
   push:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://github.com/cncf-tags/green-reviews-tooling/blob/main/CONTRIBUTING.md
- If you want *faster* PR reviews, read the Kubernetes Best Practices: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
kind/bug
kind/documentation
kind/feature
kind/enhancement
-->

kind/bug

#### What this PR does / why we need it:

- Only run project trigger workflow for changes to scripts dir.
- Tidy up workflow naming for consistency

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

None

#### Special notes for your reviewer (optional):

