### PR TITLE
docs: Rename project workflow in deploy proposal

### DIFF
--- a/docs/proposals/proposal-001-trigger-and-deploy.md
+++ b/docs/proposals/proposal-001-trigger-and-deploy.md
@@ -147,7 +147,7 @@ Note: 08:00 UTC is chosen to be during daylight when solar energy should be avai
 
 ### Trigger
 
-The benchmark pipeline will be triggered by sending a [workflow_dispatch](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)
+The project workflow will be triggered by sending a [workflow_dispatch](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)
 event via the GitHub REST API.
 
 Inputs are
@@ -162,12 +162,13 @@ and `ebpf`
 curl -X POST \
      -H "Accept: application/vnd.github.v3+json" \
      -H "Authorization: token $GITHUB_PAT" \
-     https://api.github.com/repos/cncf-tags/green-reviews-tooling/actions/workflows/benchmark-pipeline.yaml/dispatches \
+     https://api.github.com/repos/cncf-tags/green-reviews-tooling/actions/workflows/falco-pipeline.yaml/dispatches \
      -d '{"ref":"0.2.0", "inputs": {"cncf_project": "falco", "config": "modern-ebpf","version":"0.37.0"}}'
 ```
 
-The pipeline is versioned by creating releases of the `green-reviews-tooling`
-repo. The git tag to use is passed via the `ref` param.
+The workflow is named after the project e.g. `falco-pipeline.yaml` and is
+versioned by creating releases of the `green-reviews-tooling` repo. The git tag
+to use is passed via the `ref` param.
 
 The CNCF projects will be given a GitHub fine grained access token limited to
 the `green-reviews-tooling` repo. This token will have
@@ -206,7 +207,10 @@ resources in the target namespace e.g. `falco` to be ready.
 We will use [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency)
 to only allow a single execution of the pipeline at any one time.
 
-### Cleanup
+The Deploy and Delete steps are implemented as separate GitHub Actions jobs so
+they can be reused in multiple project workflows.
+
+### Delete
 
 On completion of the pipeline run, whether it was successful or failed, the CNCF
 project resources will be deleted by deleting their flux resources.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://github.com/cncf-tags/green-reviews-tooling/blob/main/CONTRIBUTING.md
- If you want *faster* PR reviews, read the Kubernetes Best Practices: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
kind/bug
kind/documentation
kind/feature
kind/enhancement
-->

kind/documentation

#### What this PR does / why we need it:

Updates proposal 1 (deploy) to be in sync with proposal 2 (run). 

Benchmark pipeline is renamed to project workflow and is named after the CNCF project e.g. `falco-pipeline.yaml`.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

None

#### Special notes for your reviewer (optional):

See https://github.com/cncf-tags/green-reviews-tooling/pull/93/files#r1662945563 for previous discussion.
