### PR TITLE
Add benchmark_path field to projects data and benchmark-job to pipeline. (#118)

### DIFF
--- a/.github/workflows/benchmark-pipeline.yaml
+++ b/.github/workflows/benchmark-pipeline.yaml
@@ -14,7 +14,7 @@ on:
         required: true
       benchmark_path:
         description: Path to the benchmark action
-        required: true
+        required: false # TODO: change to `true` when `"benchmark_path"` is specified in `projects/projects.json`
 
 concurrency:
   group: benchmark

--- a/.github/workflows/benchmark-pipeline.yaml
+++ b/.github/workflows/benchmark-pipeline.yaml
@@ -12,6 +12,9 @@ on:
       version:
         description: Version of project to be tested e.g. 0.37.0
         required: true
+      benchmark_path:
+        description: Path to the benchmark action
+        required: true
 
 concurrency:
   group: benchmark
@@ -58,6 +61,9 @@ jobs:
           --all \
           --for=condition=Ready \
           --namespace=benchmark
+
+  benchmark-job:
+    uses: ${{ inputs.benchmark_path }}
 
   delete:
     runs-on: ubuntu-22.04

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -3,6 +3,7 @@
         {
             "name": "falco",
             "organization": "falcosecurity",
+            "benchmark_path": "",
             "configs": [
                 "ebpf",
                 "modern-ebpf",

--- a/scripts/project-trigger.sh
+++ b/scripts/project-trigger.sh
@@ -16,10 +16,12 @@ fi
 jq -c '.projects[]' "$json_file" | while read -r project; do
     proj_name=$(echo "$project" | jq -r '.name')
     proj_organization=$(echo "$project" | jq -r '.organization')
+    proj_benchmark_path=$(echo "$project" | jq -r '.benchmark_path')
     configs=$(echo "$project" | jq -r '.configs')
 
     echo "Project Name: $proj_name"
     echo "Organization: $proj_organization"
+    echo "Benchmark Path: $proj_benchmark_path"
     echo "Configs: $configs"
 
     release_url="https://api.github.com/repos/${proj_organization}/${proj_name}/releases/latest"


### PR DESCRIPTION
#### What type of PR is this?
kind/enhancement

#### What this PR does / why we need it:
This PR adds the new field  `benchmark_path` to project.json and adds a new job to the benchmark pipeline that uses the specified path.

#### Which issue(s) this PR fixes:
Fixes #118 

#### Special notes for your reviewer (optional):

