### PR TITLE
Add benchmark workflow and set `benchmark_path` for Falco

### DIFF
--- a/.github/workflows/benchmark-pipeline.yaml
+++ b/.github/workflows/benchmark-pipeline.yaml
@@ -21,71 +21,71 @@ concurrency:
   group: benchmark
 
 jobs:
-  deploy:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-kubectl@v4
-        with:
-          version: v1.30.2
-        id: install
-      - run: mkdir ~/.kube && echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
-      - name: Select the manifest
-        run: |
-          MANIFEST=projects/${{ inputs.cncf_project }}
-          CONFIG=${{ inputs.config }}
-          if [[ -n $CONFIG ]]; then
-            echo "Configuration provided"
-            MANIFEST=$MANIFEST/$CONFIG.yaml
-          else
-            MANIFEST=$MANIFEST/${{ inputs.cncf_project }}.yaml
-          fi
+  # deploy:
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: azure/setup-kubectl@v4
+  #       with:
+  #         version: v1.30.2
+  #       id: install
+  #     - run: mkdir ~/.kube && echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
+  #     - name: Select the manifest
+  #       run: |
+  #         MANIFEST=projects/${{ inputs.cncf_project }}
+  #         CONFIG=${{ inputs.config }}
+  #         if [[ -n $CONFIG ]]; then
+  #           echo "Configuration provided"
+  #           MANIFEST=$MANIFEST/$CONFIG.yaml
+  #         else
+  #           MANIFEST=$MANIFEST/${{ inputs.cncf_project }}.yaml
+  #         fi
 
-          if ! test -f "$MANIFEST"; then
-            echo "The provided inputs are invalid."
-            exit 1
-          fi
+  #         if ! test -f "$MANIFEST"; then
+  #           echo "The provided inputs are invalid."
+  #           exit 1
+  #         fi
 
-          export VERSION=${{ inputs.version }}
-          envsubst < $MANIFEST > manifest.yaml
-      - uses: actions/upload-artifact@v4
-        with:
-          name: manifest
-          path: manifest.yaml
-      - name: Apply the manifest
-        run: |
-          kubectl apply -f manifest.yaml
+  #         export VERSION=${{ inputs.version }}
+  #         envsubst < $MANIFEST > manifest.yaml
+  #     - uses: actions/upload-artifact@v4
+  #       with:
+  #         name: manifest
+  #         path: manifest.yaml
+  #     - name: Apply the manifest
+  #       run: |
+  #         kubectl apply -f manifest.yaml
 
-          sleep 10
+  #         sleep 10
 
-          kubectl wait pod \
-          --all \
-          --for=condition=Ready \
-          --namespace=benchmark
+  #         kubectl wait pod \
+  #         --all \
+  #         --for=condition=Ready \
+  #         --namespace=benchmark
 
   benchmark-job:
     runs-on: ubuntu-22.04
-    needs: [deploy]
+    # needs: [deploy]
     steps:
-      - name: Checkout into repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - run: echo "$PWD"
       - uses: jenseng/dynamic-uses@v1
         with:
           uses: ${{ inputs.benchmark_path }}
 
-  delete:
-    runs-on: ubuntu-22.04
-    needs: [deploy, benchmark-job]
-    if: ${{ always() }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-kubectl@v4
-        with:
-          version: v1.30.2
-        id: install
-      - run: mkdir ~/.kube && echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
+  # delete:
+  #   runs-on: ubuntu-22.04
+  #   needs: [benchmark-job]
+  #   if: ${{ always() }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: azure/setup-kubectl@v4
+  #       with:
+  #         version: v1.30.2
+  #       id: install
+  #     - run: mkdir ~/.kube && echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: manifest
-      - run: kubectl delete -f manifest.yaml --wait
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: manifest
+  #     - run: kubectl delete -f manifest.yaml --wait

--- a/.github/workflows/benchmark-pipeline.yaml
+++ b/.github/workflows/benchmark-pipeline.yaml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: jenseng/dynamic-uses@v1
         with:
-          uses: ${{ inputs.benchmark_path }}
+          uses: ${{ inputs.benchmark_path }}@${{ github.ref_name }}
 
   delete:
     runs-on: ubuntu-22.04

--- a/.github/workflows/benchmark-pipeline.yaml
+++ b/.github/workflows/benchmark-pipeline.yaml
@@ -7,14 +7,15 @@ on:
         description: Project to be deployed e.g. falco
         required: true
       config:
-        description: Configuration if project has multiple variants they wish to test
+        description: Configuration if project has multiple variants they wish to test e.g. ebpf
         required: false
       version:
         description: Version of project to be tested e.g. 0.37.0
         required: true
       benchmark_path:
         description: Path to the benchmark action
-        required: false # TODO: change to `true` when `"benchmark_path"` is specified in `projects/projects.json`
+        type: string
+        required: true
 
 concurrency:
   group: benchmark
@@ -63,11 +64,15 @@ jobs:
           --namespace=benchmark
 
   benchmark-job:
-    uses: ${{ inputs.benchmark_path }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: jenseng/dynamic-uses@v1
+        with:
+          uses: ${{ inputs.benchmark_path }}
 
   delete:
     runs-on: ubuntu-22.04
-    needs: deploy
+    needs: [deploy, benchmark-job]
     if: ${{ always() }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/benchmark-pipeline.yaml
+++ b/.github/workflows/benchmark-pipeline.yaml
@@ -65,10 +65,13 @@ jobs:
 
   benchmark-job:
     runs-on: ubuntu-22.04
+    needs: [deploy]
     steps:
+      - name: Checkout into repository
+        uses: actions/checkout@v4
       - uses: jenseng/dynamic-uses@v1
         with:
-          uses: ${{ inputs.benchmark_path }}@${{ github.ref_name }}
+          uses: ${{ inputs.benchmark_path }}
 
   delete:
     runs-on: ubuntu-22.04

--- a/.github/workflows/benchmark-workflows/falco.yml
+++ b/.github/workflows/benchmark-workflows/falco.yml
@@ -1,0 +1,9 @@
+name: Benchmark Workflow for Falco
+
+on: workflow_dispatch
+
+jobs:
+  stress-ng-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - run: echo "done"

--- a/.github/workflows/benchmark-workflows/falco.yml
+++ b/.github/workflows/benchmark-workflows/falco.yml
@@ -6,4 +6,5 @@ jobs:
   stress-ng-test:
     runs-on: ubuntu-22.04
     steps:
-      - run: echo "done"
+      - run: |
+          echo "github.ref_name: ${{ github.ref_name }}"

--- a/.github/workflows/benchmark-workflows/falco.yml
+++ b/.github/workflows/benchmark-workflows/falco.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - run: |
-          echo "github.ref_name: ${{ github.ref_name }}"
+          echo "here"

--- a/.github/workflows/benchmark-workflows/falco.yml
+++ b/.github/workflows/benchmark-workflows/falco.yml
@@ -1,10 +1,8 @@
 name: Benchmark Workflow for Falco
-
-on: workflow_dispatch
-
-jobs:
-  stress-ng-test:
-    runs-on: ubuntu-22.04
-    steps:
-      - run: |
-          echo "here"
+description: Test composite action for Falco
+runs:
+  using: "composite"
+  steps:
+    - name: Test
+      run: echo "here"
+      shell: bash

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -3,7 +3,7 @@
         {
             "name": "falco",
             "organization": "falcosecurity",
-            "benchmark_path": "",
+            "benchmark_path": ".github/workflows/benchmark-workflows/falco.yml@nm/add-benchmark-path",
             "configs": [
                 "ebpf",
                 "modern-ebpf",

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -3,7 +3,7 @@
         {
             "name": "falco",
             "organization": "falcosecurity",
-            "benchmark_path": ".github/workflows/benchmark-workflows/falco.yml@nm/add-benchmark-path",
+            "benchmark_path": ".github/workflows/benchmark-workflows/falco.yml",
             "configs": [
                 "ebpf",
                 "modern-ebpf",

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -3,7 +3,7 @@
         {
             "name": "falco",
             "organization": "falcosecurity",
-            "benchmark_path": ".github/workflows/benchmark-workflows/falco.yml",
+            "benchmark_path": "./.github/workflows/benchmark-workflows/falco.yml",
             "configs": [
                 "ebpf",
                 "modern-ebpf",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://github.com/cncf-tags/green-reviews-tooling/blob/main/CONTRIBUTING.md
- If you want *faster* PR reviews, read the Kubernetes Best Practices: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

#### What type of PR is this?

kind/feature

#### What this PR does / why we need it:

- Sets a `benchmark_path` pointing at the benchmark workflow that will run the benchmark job and test steps
- Add a benchmark workflow in the green reviews repo

#### Which issue(s) this PR fixes:

Addresses part of https://github.com/cncf-tags/green-reviews-tooling/issues/121


