### PR TITLE
[Implementation] (Proposal 2)  Add Benchmark Pipeline 

### DIFF
--- a/.github/workflows/benchmark-pipeline.yaml
+++ b/.github/workflows/benchmark-pipeline.yaml
@@ -6,15 +6,23 @@ on:
       cncf_project:
         description: Project to be deployed e.g. falco
         required: true
+        type: string
       config:
         description: Configuration if project has multiple variants they wish to test
         required: false
+        type: string
       version:
         description: Version of project to be tested e.g. 0.37.0
         required: true
-      benchmark_path:
-        description: Path to the benchmark action
-        required: false # TODO: change to `true` when `"benchmark_path"` is specified in `projects/projects.json`
+        type: string
+      benchmark_job_url:
+        description: URL of the benchmark job
+        required: true
+        type: string
+      benchmark_job_duration:
+        description: Duration of the benchmark job
+        required: true
+        type: number
 
 concurrency:
   group: benchmark
@@ -31,10 +39,12 @@ jobs:
           echo "| cncf_project | ${{ github.event.inputs.cncf_project }} |" >> $GITHUB_STEP_SUMMARY
           echo "| config | ${{ github.event.inputs.config }} |" >> $GITHUB_STEP_SUMMARY
           echo "| version | ${{ github.event.inputs.version }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| benchmark_path | ${{ github.event.inputs.benchmark_path }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| benchmark_job_url | ${{ github.event.inputs.benchmark_job_url }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| benchmark_job_duration | ${{ github.event.inputs.benchmark_job_duration }} |" >> $GITHUB_STEP_SUMMARY
+
 
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: azure/setup-kubectl@v4
@@ -76,11 +86,38 @@ jobs:
           --namespace=benchmark
 
   benchmark-job:
-    uses: ${{ inputs.benchmark_path }}
+    runs-on: ubuntu-24.04
+    needs: deploy
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-kubectl@v4
+        with:
+          version: v1.30.2
+        id: install
+      - run: mkdir ~/.kube && echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
+      - name: Run the benchmark job
+        run: |
+          kubectl apply -f ${{ inputs.benchmark_job_url }}
+
+          kubectl wait pod \
+          --all \
+          --for=condition=Ready
+
+      - name: Wait for the benchmark job to complete
+        run: |
+          sleep ${{ inputs.benchmark_job_duration }}m
+
+      # - name: Download the benchmark results
+      #   run: |
+      #     kubectl cp benchmark:/results results
+
+      - name: Delete the benchmark job
+        run: |
+          kubectl delete -f ${{ inputs.benchmark_job_url }} --wait
 
   delete:
-    runs-on: ubuntu-22.04
-    needs: deploy
+    runs-on: ubuntu-24.04
+    needs: benchmark-job
     if: ${{ always() }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/benchmark-pipeline.yaml
+++ b/.github/workflows/benchmark-pipeline.yaml
@@ -19,7 +19,7 @@ on:
         description: URL of the benchmark job
         required: true
         type: string
-      benchmark_job_duration:
+      benchmark_job_duration_mins:
         description: Duration of the benchmark job
         required: true
         type: number
@@ -40,7 +40,7 @@ jobs:
           echo "| config | ${{ github.event.inputs.config }} |" >> $GITHUB_STEP_SUMMARY
           echo "| version | ${{ github.event.inputs.version }} |" >> $GITHUB_STEP_SUMMARY
           echo "| benchmark_job_url | ${{ github.event.inputs.benchmark_job_url }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| benchmark_job_duration | ${{ github.event.inputs.benchmark_job_duration }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| benchmark_job_duration_mins | ${{ github.event.inputs.benchmark_job_duration_mins }} |" >> $GITHUB_STEP_SUMMARY
 
 
   deploy:
@@ -105,11 +105,7 @@ jobs:
 
       - name: Wait for the benchmark job to complete
         run: |
-          sleep ${{ inputs.benchmark_job_duration }}m
-
-      # - name: Download the benchmark results
-      #   run: |
-      #     kubectl cp benchmark:/results results
+          sleep ${{ inputs.benchmark_job_duration_mins }}m
 
       - name: Delete the benchmark job
         run: |

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -4,7 +4,7 @@
             "name": "falco",
             "organization": "falcosecurity",
             "benchmark": {
-                "k8s_manifest_url": "https://raw.githubusercontent.com/falcosecurity/cncf-green-review-testing/refs/heads/main/benchmark-tests/falco-benchmark-tests.yaml",
+                "k8s_manifest_url": "https://raw.githubusercontent.com/falcosecurity/cncf-green-review-testing/e93136094735c1a52cbbef3d7e362839f26f4944/benchmark-tests/falco-benchmark-tests.yaml",
                 "duration_mins": 15
             },
             "configs": [

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -3,7 +3,10 @@
         {
             "name": "falco",
             "organization": "falcosecurity",
-            "benchmark_path": "",
+            "benchmark": {
+                "k8s_manifest_url": "https://raw.githubusercontent.com/falcosecurity/cncf-green-review-testing/refs/heads/main/benchmark-tests/deployments.yaml",
+                "duration_mins": 15
+            },
             "configs": [
                 "ebpf",
                 "modern-ebpf",

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -4,7 +4,7 @@
             "name": "falco",
             "organization": "falcosecurity",
             "benchmark": {
-                "k8s_manifest_url": "https://raw.githubusercontent.com/falcosecurity/cncf-green-review-testing/refs/heads/main/benchmark-tests/deployments.yaml",
+                "k8s_manifest_url": "https://raw.githubusercontent.com/falcosecurity/cncf-green-review-testing/refs/heads/main/benchmark-tests/falco-benchmark-tests.yaml",
                 "duration_mins": 15
             },
             "configs": [

--- a/scripts/project-trigger.sh
+++ b/scripts/project-trigger.sh
@@ -16,12 +16,14 @@ fi
 jq -c '.projects[]' "$json_file" | while read -r project; do
     proj_name=$(echo "$project" | jq -r '.name')
     proj_organization=$(echo "$project" | jq -r '.organization')
-    proj_benchmark_path=$(echo "$project" | jq -r '.benchmark_path')
+    proj_benchmark_path=$(echo "$project" | jq -r '.benchmark.k8s_manifest_url')
+    proj_benchmark_duration=$(echo "$project" | jq -r '.benchmark.duration_mins')
     configs=$(echo "$project" | jq -r '.configs')
 
     echo "Project Name: $proj_name"
     echo "Organization: $proj_organization"
     echo "Benchmark Path: $proj_benchmark_path"
+    echo "Benchmark Duration: $proj_benchmark_duration"
     echo "Configs: $configs"
 
     release_url="https://api.github.com/repos/${proj_organization}/${proj_name}/releases/latest"
@@ -50,7 +52,7 @@ jq -c '.projects[]' "$json_file" | while read -r project; do
             -H "Authorization: Bearer $gh_token" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/$workflow_organization_name/$workflow_project_name/actions/workflows/$workflow_dispatcher_file_name/dispatches" \
-            -d "{\"ref\":\"${git_ref}\",\"inputs\":{\"cncf_project\":\"${proj_name}\",\"config\":\"\",\"version\":\"${latest_proj_version}\"}}")
+            -d "{\"ref\":\"${git_ref}\",\"inputs\":{\"cncf_project\":\"${proj_name}\",\"benchmark_job_url\":\"${proj_benchmark_path}\",\"benchmark_job_duration\":\"${proj_benchmark_duration}\",\"config\":\"\",\"version\":\"${latest_proj_version}\"}}")
 
         status_code=$?
         if [ $status_code -ne 0 ]; then
@@ -68,7 +70,7 @@ jq -c '.projects[]' "$json_file" | while read -r project; do
                 -H "Authorization: Bearer $gh_token" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 "https://api.github.com/repos/$workflow_organization_name/$workflow_project_name/actions/workflows/$workflow_dispatcher_file_name/dispatches" \
-                -d "{\"ref\":\"${git_ref}\",\"inputs\":{\"cncf_project\":\"${proj_name}\",\"config\":\"${config}\",\"version\":\"${latest_proj_version}\"}}")
+                -d "{\"ref\":\"${git_ref}\",\"inputs\":{\"cncf_project\":\"${proj_name}\",\"benchmark_job_url\":\"${proj_benchmark_path}\",\"benchmark_job_duration\":\"${proj_benchmark_duration}\",\"config\":\"${config}\",\"version\":\"${latest_proj_version}\"}}")
 
             status_code=$?
             if [ $status_code -ne 0 ]; then

--- a/scripts/project-trigger.sh
+++ b/scripts/project-trigger.sh
@@ -16,14 +16,14 @@ fi
 jq -c '.projects[]' "$json_file" | while read -r project; do
     proj_name=$(echo "$project" | jq -r '.name')
     proj_organization=$(echo "$project" | jq -r '.organization')
-    proj_benchmark_path=$(echo "$project" | jq -r '.benchmark.k8s_manifest_url')
-    proj_benchmark_duration=$(echo "$project" | jq -r '.benchmark.duration_mins')
+    proj_benchmark_manifest_url=$(echo "$project" | jq -r '.benchmark.k8s_manifest_url')
+    proj_benchmark_duration_mins=$(echo "$project" | jq -r '.benchmark.duration_mins')
     configs=$(echo "$project" | jq -r '.configs')
 
     echo "Project Name: $proj_name"
     echo "Organization: $proj_organization"
-    echo "Benchmark Path: $proj_benchmark_path"
-    echo "Benchmark Duration: $proj_benchmark_duration"
+    echo "Benchmark Manifest URL: $proj_benchmark_manifest_url"
+    echo "Benchmark Duration (Minutes): $proj_benchmark_duration_mins"
     echo "Configs: $configs"
 
     release_url="https://api.github.com/repos/${proj_organization}/${proj_name}/releases/latest"
@@ -52,7 +52,7 @@ jq -c '.projects[]' "$json_file" | while read -r project; do
             -H "Authorization: Bearer $gh_token" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/$workflow_organization_name/$workflow_project_name/actions/workflows/$workflow_dispatcher_file_name/dispatches" \
-            -d "{\"ref\":\"${git_ref}\",\"inputs\":{\"cncf_project\":\"${proj_name}\",\"benchmark_job_url\":\"${proj_benchmark_path}\",\"benchmark_job_duration\":\"${proj_benchmark_duration}\",\"config\":\"\",\"version\":\"${latest_proj_version}\"}}")
+            -d "{\"ref\":\"${git_ref}\",\"inputs\":{\"cncf_project\":\"${proj_name}\",\"benchmark_job_url\":\"${proj_benchmark_manifest_url}\",\"benchmark_job_duration_mins\":\"${proj_benchmark_duration_mins}\",\"version\":\"${latest_proj_version}\"}}")
 
         status_code=$?
         if [ $status_code -ne 0 ]; then
@@ -70,7 +70,7 @@ jq -c '.projects[]' "$json_file" | while read -r project; do
                 -H "Authorization: Bearer $gh_token" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 "https://api.github.com/repos/$workflow_organization_name/$workflow_project_name/actions/workflows/$workflow_dispatcher_file_name/dispatches" \
-                -d "{\"ref\":\"${git_ref}\",\"inputs\":{\"cncf_project\":\"${proj_name}\",\"benchmark_job_url\":\"${proj_benchmark_path}\",\"benchmark_job_duration\":\"${proj_benchmark_duration}\",\"config\":\"${config}\",\"version\":\"${latest_proj_version}\"}}")
+                -d "{\"ref\":\"${git_ref}\",\"inputs\":{\"cncf_project\":\"${proj_name}\",\"benchmark_job_url\":\"${proj_benchmark_manifest_url}\",\"benchmark_job_duration_mins\":\"${proj_benchmark_duration}\",\"config\":\"${config}\",\"version\":\"${latest_proj_version}\"}}")
 
             status_code=$?
             if [ $status_code -ne 0 ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://github.com/cncf-tags/green-reviews-tooling/blob/main/CONTRIBUTING.md
- If you want *faster* PR reviews, read the Kubernetes Best Practices: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

#### What type of PR is this?
kind/feature
<!--
Add one of the following kinds:
kind/bug
kind/documentation
kind/feature
kind/enhancement
-->

#### What this PR does / why we need it:
It will give us a alternative route to use kubernetes manifests for the benchmark jobs instead of reusing github workflow.

With this we are trying to use the manifest location in github or any public facing endpoint from where we can get them


#### Which issue(s) this PR fixes:

Addresses part of #121
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer (optional):

Created this for finding alternative route for the current proposal 2 impl

Refer: #124, https://github.com/cncf-tags/green-reviews-tooling/issues/121#issuecomment-2476378468