### PR TITLE
fix: Don't run trigger on PR as secret not available

### DIFF
--- a/.github/workflows/project-trigger.yml
+++ b/.github/workflows/project-trigger.yml
@@ -3,11 +3,6 @@ name: Project Trigger
 on:
   schedule:
     - cron: '0 8 * * *'
-  pull_request:
-    branches:
-    - main
-    paths:
-    - 'scripts/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://github.com/cncf-tags/green-reviews-tooling/blob/main/CONTRIBUTING.md
- If you want *faster* PR reviews, read the Kubernetes Best Practices: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
kind/bug
kind/documentation
kind/feature
kind/enhancement
-->

kind/bug

#### What this PR does / why we need it:

The project trigger action runs for some pull requests e.g. #127 but it uses a GH secret that is not accessible from forked repos. 

So it fails which is confusing when reviewing. This disables the action for pull requests only.

#### Which issue(s) this PR fixes:

Fixes #129 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer (optional):

