### PR TITLE
Add deployment CRUD perms to pipeline service account

### DIFF
--- a/scripts/pipeline-kubeconfig-resources.yaml
+++ b/scripts/pipeline-kubeconfig-resources.yaml
@@ -24,6 +24,10 @@ rules:
     resources:
       - kustomizations
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:

Tested Dipankar's PR: https://github.com/cncf-tags/green-reviews-tooling/actions/runs/12066994645
Looks like we need to add CRUD perms to the pipeline's Service Account.

#### Which issue(s) this PR fixes:

None
