### PR TITLE
fix: Add perms for watching pods to pipeline role

### DIFF
--- a/clusters/base/pipeline-kubeconfig-resources.yaml
+++ b/clusters/base/pipeline-kubeconfig-resources.yaml
@@ -28,6 +28,10 @@ rules:
     resources:
       - deployments
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://github.com/cncf-tags/green-reviews-tooling/blob/main/CONTRIBUTING.md
- If you want *faster* PR reviews, read the Kubernetes Best Practices: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
kind/bug
kind/documentation
kind/feature
kind/enhancement
-->

kind/bug

#### What this PR does / why we need it:

Fix for `error: no matching resources found` when waiting for pods

https://github.com/cncf-tags/green-reviews-tooling/actions/runs/12071256142

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer (optional):

