### PR TITLE
fix: Add namespace to kubectl wait

### DIFF
--- a/.github/workflows/benchmark-pipeline.yaml
+++ b/.github/workflows/benchmark-pipeline.yaml
@@ -103,7 +103,8 @@ jobs:
 
           kubectl wait pod \
           --all \
-          --for=condition=Ready
+          --for=condition=Ready \
+          --namespace=falco # TODO: Revert to "benchmark" this after merging https://github.com/falcosecurity/cncf-green-review-testing/pull/22
 
       - name: Wait for the benchmark job to complete
         run: |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://github.com/cncf-tags/green-reviews-tooling/blob/main/CONTRIBUTING.md
- If you want *faster* PR reviews, read the Kubernetes Best Practices: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
kind/bug
kind/documentation
kind/feature
kind/enhancement
-->

kind/bug

#### What this PR does / why we need it:

Fix for pipeline as without namespace `kubectl wait` fails


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer (optional):

```
k --kubeconfig /tmp/pipeline-kubeconfig wait pod \
          --all \
          --for=condition=Ready
error: no matching resources found
```

```
k --kubeconfig /tmp/pipeline-kubeconfig wait pod \
          --all \
          --for=condition=Ready \
          --namespace=falco
pod/falco-event-generator-7f74b9cf77-s52fk condition met
pod/redis-7d65c855db-wtgk5 condition met
pod/stress-ng-85b4869f47-d72tj condition met
```