### PR TITLE
fix: Benchmark param name and add sleep prior to kubectl wait

### DIFF
--- a/.github/workflows/benchmark-pipeline.yaml
+++ b/.github/workflows/benchmark-pipeline.yaml
@@ -80,12 +80,12 @@ jobs:
         run: |
           kubectl apply -f manifest.yaml
 
-          sleep 10
+          sleep 20
 
           kubectl wait pod \
           --all \
           --for=condition=Ready \
-          --namespace=falco # TODO: Revert to "benchmark" this after merging https://github.com/falcosecurity/cncf-green-review-testing/pull/22
+          --namespace=benchmark
 
   benchmark-job:
     runs-on: ubuntu-24.04
@@ -100,6 +100,8 @@ jobs:
       - name: Run the benchmark job
         run: |
           kubectl apply -f ${{ inputs.benchmark_job_url }}
+          
+          sleep 20
 
           kubectl wait pod \
           --all \

--- a/scripts/project-trigger.sh
+++ b/scripts/project-trigger.sh
@@ -70,7 +70,7 @@ jq -c '.projects[]' "$json_file" | while read -r project; do
                 -H "Authorization: Bearer $gh_token" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 "https://api.github.com/repos/$workflow_organization_name/$workflow_project_name/actions/workflows/$workflow_dispatcher_file_name/dispatches" \
-                -d "{\"ref\":\"${git_ref}\",\"inputs\":{\"cncf_project\":\"${proj_name}\",\"benchmark_job_url\":\"${proj_benchmark_manifest_url}\",\"benchmark_job_duration_mins\":\"${proj_benchmark_duration}\",\"config\":\"${config}\",\"version\":\"${latest_proj_version}\"}}")
+                -d "{\"ref\":\"${git_ref}\",\"inputs\":{\"cncf_project\":\"${proj_name}\",\"benchmark_job_url\":\"${proj_benchmark_manifest_url}\",\"benchmark_job_duration_mins\":\"${proj_benchmark_duration_mins}\",\"config\":\"${config}\",\"version\":\"${latest_proj_version}\"}}")
 
             status_code=$?
             if [ $status_code -ne 0 ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://github.com/cncf-tags/green-reviews-tooling/blob/main/CONTRIBUTING.md
- If you want *faster* PR reviews, read the Kubernetes Best Practices: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
kind/bug
kind/documentation
kind/feature
kind/enhancement
-->

kind/bug

#### What this PR does / why we need it:

- Fixes incorrect param name in trigger script.
- Adds sleeps before wait in case there is a delay creating pods.
- Fixes namespace when waiting for falco pods.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer (optional):
