### PR TITLE
Changing concurrency behavior to allow for queued pipelines

### DIFF
--- a/.github/workflows/benchmark-pipeline.yaml
+++ b/.github/workflows/benchmark-pipeline.yaml
@@ -28,6 +28,7 @@ on:
 
 concurrency:
   group: benchmark
+  cancel-in-progress: false
 
 jobs:
   print_summary:
@@ -43,7 +44,6 @@ jobs:
           echo "| version | ${{ github.event.inputs.version }} |" >> $GITHUB_STEP_SUMMARY
           echo "| benchmark_job_url | ${{ github.event.inputs.benchmark_job_url }} |" >> $GITHUB_STEP_SUMMARY
           echo "| benchmark_job_duration_mins | ${{ github.event.inputs.benchmark_job_duration_mins }} |" >> $GITHUB_STEP_SUMMARY
-
 
   deploy:
     runs-on: ubuntu-24.04
@@ -100,7 +100,7 @@ jobs:
       - name: Run the benchmark job
         run: |
           kubectl apply -f ${{ inputs.benchmark_job_url }}
-          
+
           sleep 20
 
           kubectl wait pod \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://github.com/cncf-tags/green-reviews-tooling/blob/main/CONTRIBUTING.md
- If you want *faster* PR reviews, read the Kubernetes Best Practices: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

#### What type of PR is this?
kind/bug
<!--
Add one of the following kinds:
kind/bug
kind/documentation
kind/feature
kind/enhancement
-->

#### What this PR does / why we need it:

This PR updates the concurrency behavior of the benchmark pipeline to address issues with job cancellations when multiple workflows are triggered simultaneously. Previously, only two pipelines could run at a time, and additional workflows were canceled due to the default concurrency settings.

#### Which issue(s) this PR fixes:
Fixes #142 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer (optional):

Since this if for a workflow where I don't have the secrets/permissions to trigger, we'll need to verify that this change produces the desired behavior once the pipeline is triggered. According to the documentation, it should.