### PR TITLE
fix: Trigger pipeline weekly on Wednesdays

### DIFF
--- a/.github/workflows/project-trigger.yml
+++ b/.github/workflows/project-trigger.yml
@@ -2,7 +2,7 @@ name: Project Trigger
 
 on:
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 8 * * 3'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://github.com/cncf-tags/green-reviews-tooling/blob/main/CONTRIBUTING.md
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
kind/bug
kind/documentation
kind/feature
kind/enhancement
-->

kind/enhancement

#### What this PR does / why we need it:

Quick win to run pipeline once a week on Wednesday at 08:00 UTC instead of daily.

This is so we consume less Oracle Cloud resources.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer (optional):

